### PR TITLE
chore: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Description**
+A clear and concise description of what the bug is.
+
+**Steps to Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. macOS, Windows]
+ - Version [e.g. 22]
+
+**Additional Context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Description**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Proposed Solution**
+A clear and concise description of what you want to happen.
+
+**Alternatives Considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional Context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+**Description**
+Please include a summary of the change and which issue is fixed.
+
+**Related Issue**
+Fixes # (issue)
+
+**Type of Change**
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+**Checklist:**
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings


### PR DESCRIPTION
### Summary
This PR adds standard GitHub issue and pull request templates to improve consistency and clarity when reporting bugs, requesting features, and opening PRs.

### What changed
- Added a bug report issue template.
- Added a feature request issue template.
- Added a pull request template.
- All changes are limited to the `.github/` directory.

### Scope & Intent
- Repository metadata only.
- No application code, logic, configuration, or workflows were modified.
- Templates follow GitHub best practices and keep wording generic and contributor-friendly.

### Related issue
- References: #103
- 