### PR TITLE
Pass config to bucket_utils.get_bucket_name

### DIFF
--- a/src/gearbox/services/eligibility_criteria.py
+++ b/src/gearbox/services/eligibility_criteria.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, Request
 from gearboxdatamodel.util import status
 from gearbox.util import bucket_utils, qc
 from gearboxdatamodel.util.types import EligibilityCriteriaStatus
+from gearbox import config
 
 async def reset_active_status(session: Session, study_version_id: int) -> bool:
     # set all rows related to the study_version to false
@@ -88,7 +89,7 @@ async def get_eligibility_criteria_set(session, id: int=None):
 async def build_eligibility_criteria(session: Session,request: Request) -> EligibilityCriteriaSearchResults: 
 
     eligibility_criteria = await get_eligibility_criteria_set(session)
-    bucket_name = bucket_utils.get_bucket_name()
+    bucket_name = bucket_utils.get_bucket_name(config)
 
     if not config.BYPASS_S3:
         params = [{'Content-Type':'application/json'}]

--- a/src/gearbox/services/match_conditions.py
+++ b/src/gearbox/services/match_conditions.py
@@ -573,7 +573,7 @@ async def get_match_conditions(session: Session) -> List[AlgorithmResponse]:
 async def build_match_conditions(session: Session, request: Request) -> List[AlgorithmResponse]:
 
     match_conditions = await get_match_conditions(session)
-    bucket_name = bucket_utils.get_bucket_name()
+    bucket_name = bucket_utils.get_bucket_name(config)
 
     if not config.BYPASS_S3:
         params = [{'Content-Type':'application/json'}]

--- a/src/gearbox/services/match_form.py
+++ b/src/gearbox/services/match_form.py
@@ -18,7 +18,7 @@ import re
 async def build_match_form(session: Session, request: Request, save: bool):
 
     match_form = await get_match_form(session)
-    bucket_name = bucket_utils.get_bucket_name()
+    bucket_name = bucket_utils.get_bucket_name(config)
     if save:
         if not config.BYPASS_S3:
             params = [{'Content-Type':'application/json'}]

--- a/src/gearbox/services/study.py
+++ b/src/gearbox/services/study.py
@@ -326,7 +326,7 @@ def get_new_version(study_info: dict) -> str:
 async def build_studies(session: Session, request: Request) -> StudySchema:
 
     results = await get_studies_info(session)
-    bucket_name = bucket_utils.get_bucket_name()
+    bucket_name = bucket_utils.get_bucket_name(config)
     existing_studies = bucket_utils.get_object(request=request, bucket_name=bucket_name, key_name=config.S3_BUCKET_STUDIES_KEY_NAME, expires=300, method="get_object")
     version = get_new_version(existing_studies)
     studies = [StudySchema.model_validate(obj=study_obj, from_attributes=True) for study_obj in results]


### PR DESCRIPTION
Update service builders to pass the config module into bucket_utils.get_bucket_name so bucket resolution uses explicit configuration. Added import of gearbox.config in eligibility_criteria and updated calls in eligibility_criteria.py, match_conditions.py, match_form.py, and study.py to use bucket_utils.get_bucket_name(config). This ensures consistent S3 bucket lookup and respects BYPASS_S3/config settings.